### PR TITLE
fix: 修复了向已结束的流发送数据的bug

### DIFF
--- a/src/engine/huya/message.ts
+++ b/src/engine/huya/message.ts
@@ -89,7 +89,10 @@ export const getHuyaSteam = (stream: HuyaStreamInfo) => {
     tags.push("LOL", "英雄联盟")
     upload2bilibili(dirName, `${stream.streamName} ${timeV}录播`, ``, tags, stream.liveUrl)
   });
-  process.on("SIGINT", () => {
-    huyaApp.stdin.end('q')
+  process.on("SIGINT", async () => {
+    if (huyaApp.stdin._writableState.ended == false) {
+      // 流是否已经结束
+      huyaApp.stdin.end('q')
+    }
   })
 };


### PR DESCRIPTION
`Ctrl+C`会向ffmpeg进程发送指令使其结束，同时流终止，之后如果再次接收到`Ctrl+C`，会错误的向已终止的流发送指令。