### PR TITLE
将视频简介提取到info.json中，让修改更方便

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -48,7 +48,7 @@ const timer = setInterval(() => {
                         let timeNow = dayjs().format("YYYY-MM-DD")
                         if (timeNow !== curRecorder.timeV) {
                             logger.info(`日期改变，上传前一天的录播文件`)
-                            submit(curRecorder.dirName, curRecorder.recorderName, curRecorder.recorderLink, curRecorder.timeV, curRecorder.tags, curRecorder.tid)
+                            submit(curRecorder.dirName, curRecorder.recorderName, curRecorder.recorderLink, curRecorder.timeV, curRecorder.tags, curRecorder.tid,curRecorder.intros)
                         }
                         curRecorder.startRecord(stream)
                     }
@@ -64,7 +64,7 @@ const timer = setInterval(() => {
                     if (curRecorder.recorderStat() === true) {
                         curRecorder.stopRecord()
                     }
-                    submit(curRecorder.dirName, curRecorder.recorderName, curRecorder.recorderLink, curRecorder.timeV, curRecorder.tags,curRecorder.tid)
+                    submit(curRecorder.dirName, curRecorder.recorderName, curRecorder.recorderLink, curRecorder.timeV, curRecorder.tags,curRecorder.tid,curRecorder.intros)
                     recorderPool.splice(curRecorderIndex, 1);
                 }
             });
@@ -82,14 +82,18 @@ process.on("SIGINT", () => {
     clearInterval(timer)
 })
 
+const introAdd = (introArr: string[]) => {
+    // const temp = ` 本录播由StreamerHelper强力驱动:  https://github.com/ZhangMingZhao1/StreamerHelper，对您有帮助的话，求个star`
+    return introArr.join("\n")
+}
 
-const submit = (dirName: string, roomName: string, roomLink: string, timeV: string, tags: string[], tid: Number) => {
+const submit = (dirName: string, roomName: string, roomLink: string, timeV: string, tags: string[], tid: Number, intros: string[]) => {
     if (uploadStatus.get(dirName) === 1) {
         logger.info(`目录 ${dirName} 正在上传中，避免重复上传，取消此次上传任务`)
         return
     }
     uploadStatus.set(dirName, 1)
-    upload2bilibili(dirName, `${roomName} ${timeV}录播`, ` 本录播由StreamerHelper强力驱动:  https://github.com/ZhangMingZhao1/StreamerHelper，对您有帮助的话，求个star`, tags, roomLink, tid)
+    upload2bilibili(dirName, `${roomName} ${timeV}录播`, introAdd(intros), tags, roomLink, tid)
         .then((message) => {
             uploadStatus.set(dirName, 0)
             logger.info(message)

--- a/src/engine/message.ts
+++ b/src/engine/message.ts
@@ -16,6 +16,7 @@ export class Recorder {
   timeV!: string;
   tags!: string[];
   tid!: Number
+  intros!: string[];
   App!: any;
   ffmpegProcessEnd: boolean = false;
 

--- a/templates/info.json
+++ b/templates/info.json
@@ -13,6 +13,12 @@
           "英雄联盟",
           "电子竞技",
           "iG"
+        ],
+        "intros": [
+          "本录播由StreamerHelper强力驱动:",
+          "  https://github.com/ZhangMingZhao1/StreamerHelper，",
+          "对您有帮助的话，",
+          "求个star!"
         ]
       }
     }


### PR DESCRIPTION
很小的一个修改。
在info.json下添加一个intros字段
统一而方便的在info.json修改视频的简介内容。

intros数组每一个元素即代表视频简介的一行。

大佬觉得这样可以吗？

```text
{
  "personInfo": {
    "username": "",
    "password": "",
    "access_token":""
  },
  "streamerInfo": [
    {
      "iGNing": {
        "roomUrl": "https://www.huya.com/980312",
        "tid":21,
        "tags": [
          "英雄联盟",
          "电子竞技",
          "iG"
        ],
        "intros": [
          "本录播由StreamerHelper强力驱动:",
          "  https://github.com/ZhangMingZhao1/StreamerHelper，",
          "对您有帮助的话，",
          "求个star!"
        ]
      }
    }
  ]
}
```
