### PR TITLE
fix Cannot read property failUpload of undefinded

### DIFF
--- a/src/uploader/index.ts
+++ b/src/uploader/index.ts
@@ -518,10 +518,13 @@ export class uploader {
         // Merge a `source` object to a `target` recursively
         const merge = (target: any, source: any) => {
             // Iterate through `source` properties and if an `Object` set property to merge of `target` and `source` properties
-            for (const key of Object.keys(source)) {
-                if (source[key] instanceof Object) Object.assign(source[key], merge(target[key], source[key]))
+            //Add checkpoints 增加校验
+            if(target){
+                for (const key of Object.keys(source)) {
+                    if (source[key] instanceof Object) Object.assign(source[key], merge(target[key], source[key]))
+                }
             }
-
+            
             // Join `target` and modified `source`
             Object.assign(target || {}, source)
             return target


### PR DESCRIPTION
增加校验，没有上传过的fileStatus.json文件里面没有videoParts字段，merge传了个fileStatus.json中没有的videoParts字段进去，然后调用json转的对象的videoParts，获取到的是undefind，然后再读undefind.failUpload自然就报错了
![8WP E`W~{ ~@QCZR)X79`QI](https://user-images.githubusercontent.com/44561136/130032351-e1dc33f7-b2ff-4263-a12c-e78ea76e0655.jpg)

![_LU)87)JK2BM(_K 6NJD(KU](https://user-images.githubusercontent.com/44561136/130032327-91c2ac24-0570-4495-8887-ae5b9b380f44.jpg)
![TG9MM}7YP2{`Z41 KGZ6QMK](https://user-images.githubusercontent.com/44561136/130032334-8cea57c9-4e85-40f3-8c26-2db02956ce03.jpg)
