### PR TITLE
更换获取用户信息接口，修复了无法获取信息导致程序中断问题

### DIFF
--- a/src/uploader/user.ts
+++ b/src/uploader/user.ts
@@ -104,10 +104,17 @@ export class User {
                 this.logger.error(`Access Token not define`)
                 return reject()
             }
-            const url = `https://api.snm0516.aisee.tv/x/tv/account/myinfo?access_key=${this._access_token}`
+            const params: any = {
+                access_key: this._access_token,
+                appkey: '4409e2ce8ffd12b8',
+                ts: parseInt(String(new Date().valueOf() / 1000))
+            }
+            params.sign = md5(crypt.make_sign(params, "59b43e04ad6965f34319062b478f83dd"))
             try {
                 const { data: { data, code, message } } = await $axios.request<BiliAPIResponse<GetUserInfoResponse>>({
-                    url
+                    url: 'https://app.bilibili.com/x/v2/account/myinfo',
+                    method: "get",
+                    params
                 })
 
                 this.logger.debug('Get user info response: ')


### PR DESCRIPTION
此前的获取用户信息接口疑似废弃，导致程序获取不到用户信息从而中断（但登陆正常，可以拿到 access_token 以及 refresh_token），更换了新的用户信息接口，解决了 #176 #177 #184 等无法登录 B 站的 issue